### PR TITLE
Added "standard action" item for opening the notifications drawer/quick settings panel

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.EXPAND_STATUS_BAR"/>
 
     <!-- for receiving pinned shortcuts (maybe older Android versions) -->
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT"/>

--- a/app/src/main/java/de/theiling/neatlauncher/MainActivity.kt
+++ b/app/src/main/java/de/theiling/neatlauncher/MainActivity.kt
@@ -857,7 +857,26 @@ class MainActivity:
         try {
             when (item.type) {
                 ITEM_TYPE_APP -> packageIntent(item.pack)?.let { startActivity(it) }
-                ITEM_TYPE_INT -> if (item.act != "") startActivity(Intent(item.act))
+                ITEM_TYPE_INT -> {
+                    when (item.act) {
+                        "OPEN_NOTIFICATIONS" -> {
+                            try {
+                                val statusBarService = getSystemService("statusbar")
+                                val statusBarManager = Class.forName("android.app.StatusBarManager")
+                                val expandNotificationsPanel = statusBarManager.getMethod("expandNotificationsPanel")
+                                expandNotificationsPanel.invoke(statusBarService)
+                            } catch (e: Exception) {
+                                e.printStackTrace()
+                                shortToast(getString(R.string.open_notifications_failed))
+                            }
+                        }
+                        "" -> {
+                        }
+                        else -> {
+                            startActivity(Intent(item.act))
+                        }
+                    }
+                }
                 ITEM_TYPE_SHORT,
                 ITEM_TYPE_PIN -> if (Build.VERSION.SDK_INT >= 25) {
                     val uha = getUserHandle(item.uid)

--- a/app/src/main/java/de/theiling/neatlauncher/MainActivity.kt
+++ b/app/src/main/java/de/theiling/neatlauncher/MainActivity.kt
@@ -630,6 +630,7 @@ class MainActivity:
 
         // Standard Actions
         items.add(Item(c, ITEM_TYPE_INT, null, getString(R.string.item_nothing), "", "", myUid))
+        items.add(Item(c, ITEM_TYPE_INT, null, getString(R.string.item_open_notifications), "", "OPEN_NOTIFICATIONS", myUid))
 
         // Arbitrary list of standard intents.  FIXME: this needs some love.
         val intents = listOf(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -101,6 +101,9 @@
     <string name="item_camera">Kamera</string>
     <string name="item_settings">Einstellungen</string>
     <string name="item_phone">Telefon</string>
+    
+    <string name="item_open_notifications">Benachrichtigungen öffnen</string>
+    <string name="open_notifications_failed">Konnte Benachrichtigungen nicht öffnen</string>
 
     <string name="item_start">Starten</string>
     <string name="item_info">App-Info</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,9 @@
     <string name="item_camera">Camera</string>
     <string name="item_settings">Settings</string>
     <string name="item_phone">Phone</string>
+    
+    <string name="item_open_notifications">Open Notifications</string>
+    <string name="open_notifications_failed">Failed to open notifications</string>
 
     <string name="item_start">Start</string>
     <string name="item_info">App Info</string>


### PR DESCRIPTION
This commit adds another item to the app drawer, called "Open Notifications". Launching it will open the notification drawer/quick settings panel.

Use case: This allows to assign the swipe down gesture to this item, making opening the notifications drawer from the home screen much easier.